### PR TITLE
disk-image-checks: add portal/UI triage (recent_changes, tiny_backdoor, ns_conf) and portal_exfil enhancements

### DIFF
--- a/disk-image-checks/checks.yaml
+++ b/disk-image-checks/checks.yaml
@@ -52,6 +52,153 @@ checks:
             - /etc/rc
             - /etc/rc.conf.defaults
 
+        - name: portal_exfil
+          suspicious_contents:
+            # Loosen heads to also allow data: and blob: (no // for data:) and ports on host
+            - 'regex:<script[^>]+src=["''](https?|data|blob):'
+            - 'regex:fetch\(\s*["''](https?|data|blob):'
+            - regex:(?s)xmlhttprequest.*?open\([^,]+,\s*["']https?://
+            - regex:sendbeacon\(\s*["']https?://
+            - 'regex:new\s+image\(\)\.src\s*=\s*["''](https?|data|blob):'
+            - regex:on\w+\s*=\s*.*location\.(href|assign)\s*=["']https?://
+            - regex:postMessage\(
+            - regex:location\.(href|assign)\s*=
+            - regex:window\.location\s*=
+            - regex:(?:window|parent|top)\.location\s*=
+            - regex:(?:window|parent|top)\.location\.(href|assign)\s*=
+            - regex:new\s+WebSocket\(\s*["']wss?://
+            - regex:new\s+EventSource\(\s*["']https?://
+            - regex:navigator\.sendbeacon\(\s*["']https?://
+            - regex:navigator\.clipboard\.write(Text)?\(
+            - 'regex:fetch\(\s*`https?://'
+            - 'regex:(?s)xmlhttprequest.*?open\([^,]+,\s*`https?://'
+          paths:
+            - /var/netscaler/logon
+            - /var/netscaler/logon/LogonPoint
+            - /var/netscaler/logon/themes
+            - /var/vpn
+            - /var/netscaler/portal
+            - /netscaler/ns_gui/admin_ui
+            - /netscaler/ns_gui/vpn
+          known_paths: []
+          extensions:
+            - .html
+            - .xhtml
+            - .js
+          allowlist_patterns:
+            # Customize per org to reduce FPs
+            - regex:https?://(www\.)?google-analytics\.com
+            - regex:https?://(www\.)?googletagmanager\.com
+            - regex:https?://ajax\.googleapis\.com
+            - regex:https?://cdn\.jsdelivr\.net
+            - regex:https?://cdnjs\.cloudflare\.com
+            - regex:https?://code\.jquery\.com
+            - regex:https?://cdn\.bootstrapcdn\.com
+            - regex:https?://static\.hotjar\.com
+            - regex:https?://cdn\.segment\.com
+            - regex:https?://fonts\.googleapis\.com
+            - regex:https?://fonts\.gstatic\.com
+            - regex:https?://(www\.)?gstatic\.com
+            - regex:https?://use\.typekit\.net
+            - regex:https?://static\.cloudflareinsights\.com
+            - regex:https?://cdn\.cloudflare\.com
+            - regex:https?://ajax\.aspnetcdn\.com
+            - regex:https?://static-cdn\.resources\.citrix\.com
+            - regex:https?://login\.microsoftonline\.com
+            - regex:https?://aadcdn\.msftauth\.net
+            - regex:https?://(www\.)?okta\.com
+            - regex:https?://oktastatic\.com
+            - regex:https?://(www\.)?onelogin\.com
+            - regex:https?://(www\.)?auth0\.com
+            - regex:https?://(www\.)?pingidentity\.com
+            - regex:https?://(www\.)?pingone\.com
+        - name: portal_strings
+          suspicious_contents:
+            - regex:https?://[^"\s]+
+          paths:
+            - /var/netscaler/logon/themes
+          known_paths: []
+          extensions:
+            - .json
+          allowlist_patterns:
+            - regex:https?://(www\.)?google-analytics\.com
+            - regex:https?://(www\.)?googletagmanager\.com
+            - regex:https?://ajax\.googleapis\.com
+            - regex:https?://cdn\.jsdelivr\.net
+            - regex:https?://cdnjs\.cloudflare\.com
+            - regex:https?://code\.jquery\.com
+            - regex:https?://cdn\.bootstrapcdn\.com
+            - regex:https?://static\.hotjar\.com
+            - regex:https?://cdn\.segment\.com
+            - regex:https?://fonts\.googleapis\.com
+            - regex:https?://fonts\.gstatic\.com
+            - regex:https?://(www\.)?gstatic\.com
+            - regex:https?://use\.typekit\.net
+            - regex:https?://static\.cloudflareinsights\.com
+            - regex:https?://cdn\.cloudflare\.com
+            - regex:https?://ajax\.aspnetcdn\.com
+            - regex:https?://static-cdn\.resources\.citrix\.com
+            - regex:https?://login\.microsoftonline\.com
+            - regex:https?://aadcdn\.msftauth\.net
+            - regex:https?://(www\.)?okta\.com
+            - regex:https?://oktastatic\.com
+            - regex:https?://(www\.)?onelogin\.com
+            - regex:https?://(www\.)?auth0\.com
+            - regex:https?://(www\.)?pingidentity\.com
+            - regex:https?://(www\.)?pingone\.com
+        - name: portal_plugins
+          suspicious_contents:
+            - regex:<plugin[^>]+src=["']https?://[^"']+
+            - regex:\bsrc=["']https?://[^"']+
+          paths:
+            - /var/netscaler/logon/LogonPoint
+          known_paths: []
+          extensions:
+            - .xml
+          allowlist_patterns:
+            - regex:https?://(www\.)?google-analytics\.com
+            - regex:https?://(www\.)?googletagmanager\.com
+            - regex:https?://ajax\.googleapis\.com
+            - regex:https?://cdn\.jsdelivr\.net
+            - regex:https?://cdnjs\.cloudflare\.com
+            - regex:https?://code\.jquery\.com
+            - regex:https?://cdn\.bootstrapcdn\.com
+            - regex:https?://static\.hotjar\.com
+            - regex:https?://cdn\.segment\.com
+            - regex:https?://fonts\.googleapis\.com
+            - regex:https?://fonts\.gstatic\.com
+            - regex:https?://(www\.)?gstatic\.com
+            - regex:https?://use\.typekit\.net
+            - regex:https?://static\.cloudflareinsights\.com
+            - regex:https?://cdn\.cloudflare\.com
+            - regex:https?://ajax\.aspnetcdn\.com
+            - regex:https?://static-cdn\.resources\.citrix\.com
+            - regex:https?://login\.microsoftonline\.com
+            - regex:https?://aadcdn\.msftauth\.net
+            - regex:https?://(www\.)?okta\.com
+            - regex:https?://oktastatic\.com
+            - regex:https?://(www\.)?onelogin\.com
+            - regex:https?://(www\.)?auth0\.com
+            - regex:https?://(www\.)?pingidentity\.com
+            - regex:https?://(www\.)?pingone\.com
+
+        - name: rc_persistence
+          suspicious_contents:
+            - regex:python3?\s+-c
+            - regex:(curl|wget)[^\n]*\|\s*sh
+            - regex:touch\s+-t
+            - regex:nohup\s
+            - regex:screen\s
+            - regex:https?://
+            - regex:([^0-9]|^)([0-9]{1,3}\.){3}[0-9]{1,3}([^0-9]|$)
+          paths:
+            - /flash/nsconfig/rc.netscaler
+            - /etc/rc
+            - /etc/rc.conf
+            - /etc/rc.conf.local
+            - /etc/rc.local
+            - /etc/rc.d
+          known_paths: []
   - check: yara
     confidence: high
     args:
@@ -61,6 +208,70 @@ checks:
       paths:
         - /var
       max_file_size_kb: 1024
+
+  - check: recent_changes
+    confidence: medium
+    args:
+      paths:
+        - /var/netscaler/logon
+        - /var/netscaler/logon/LogonPoint
+        - /var/netscaler/logon/themes
+        - /var/vpn
+        - /var/netscaler/portal
+        - /netscaler/ns_gui/admin_ui
+        - /netscaler/ns_gui/vpn
+      days: 90
+      extensions:
+        - .php
+        - .php3
+        - .php4
+        - .php5
+        - .php7
+        - .pht
+        - .phtml
+        - .inc
+        - .shtml
+        - .xhtml
+        - .js
+        - .html
+        - .json
+        - .css
+
+  - check: tiny_backdoor
+    confidence: high
+    args:
+      paths:
+        - /var/netscaler/logon
+        - /var/netscaler/logon/LogonPoint
+        - /var/netscaler/logon/themes
+        - /var/vpn
+        - /var/netscaler/portal
+        - /netscaler/ns_gui/admin_ui
+        - /netscaler/ns_gui/vpn
+      max_size_kb: 64
+      extensions:
+        - .php
+        - .php3
+        - .php4
+        - .php5
+        - .php7
+        - .pht
+        - .phtml
+        - .inc
+        - .shtml
+      suspicious_patterns:
+        - regex:system\s*\(
+        - regex:shell_exec\s*\(
+        - regex:passthru\s*\(
+        - regex:(?<!\.)exec\s*\(
+        - regex:popen\s*\(
+        - regex:proc_open\s*\(
+        - regex:base64_decode\s*\(
+        - regex:assert\s*\(
+        - regex:eval\s*\(
+        - regex:preg_replace\s*\([^)]*\/e[^)]*\)
+        - regex:atob\s*\(
+        - regex:new\s+Function\s*\(
 
   - check: crontab
     confidence: high
@@ -135,6 +346,36 @@ checks:
       suspicious_bytes:
         pcap_microsecond: d4c3 b2a1
         pcap_nanosecond: 4d3c b2a1
+
+  - check: ns_conf
+    confidence: high
+    args:
+      path: /nsconfig/ns.conf
+      suspicious_patterns:
+        # Non-default theme bindings or external theme sources
+        - regex:bind\s+vpn\s+vserver\s+\S+\s+.*-portaltheme\s+(?!Default)\w+
+        - regex:add\s+vpn\s+portaltheme\s+\S+\s+.*-source\s+https?://
+        # Responder policies injecting remote content or redirects
+        - regex:add\s+responder\s+policy\s+.*https?://
+        - regex:(?s)add\s+responder\s+action\s+.*?Q\("https?://
+        # Clientless/non-default portal modes
+        - regex:set\s+vpn\s+parameter\s+.*-clientlessVpnMode\s+ON
+        # Additional rewrite/AAA pivots and toggles often abused
+        - regex:add\s+rewrite\s+(policy|action)\s+.*https?://
+        - regex:bind\s+rewrite\s+policylabel\s+\S+.*-\s*policyName\s+\S+
+        - regex:set\s+vpn\s+parameter\s+.*-forceCleanup\s+ON
+        - regex:set\s+vpn\s+vserver\s+\S+.*-clientlessAccess\s+ON
+        - regex:add\s+(lb|cs)\s+vserver\s+\S+.*-redirURL\s+https?://
+      allowlist_patterns:
+        # Common IdP endpoints likely present in SSO flows
+        - regex:https?://login\.microsoftonline\.com
+        - regex:https?://aadcdn\.msftauth\.net
+        - regex:https?://(www\.)?okta\.com
+        - regex:https?://oktastatic\.com
+        - regex:https?://(www\.)?onelogin\.com
+        - regex:https?://(www\.)?auth0\.com
+        - regex:https?://(www\.)?pingidentity\.com
+        - regex:https?://(www\.)?pingone\.com
 
   - check: core_dump
     confidence: medium

--- a/disk-image-checks/src/checker/checks.py
+++ b/disk-image-checks/src/checker/checks.py
@@ -20,6 +20,17 @@ logger = logging.getLogger("checks")
 logger.setLevel(logging.INFO)
 EXPECTED_PHP_FILE_PERMISSION = 0o444
 CORE_DUMP_CHECK_SCRIPT_URL = ""
+WEB_SHELL_EXTENSIONS = {
+    ".php",
+    ".php3",
+    ".php4",
+    ".php5",
+    ".php7",
+    ".pht",
+    ".phtml",
+    ".inc",
+    ".shtml",
+}
 
 
 def set_log_level(level):
@@ -56,7 +67,9 @@ def timestomp(
     timestomp_dirs = paths
     for timestomp_dir in timestomp_dirs:
         for path in (
-            x for x in target.fs.path(timestomp_dir).rglob("*") if x.is_file() and not _is_known_path(x, known_paths)
+            x
+            for x in target.fs.path(timestomp_dir).rglob("*")
+            if x.is_file() and not x.is_symlink() and not _is_known_path(x, known_paths)
         ):
             stat: stat_result = path.lstat()
             if not stat.st_mtime or not stat.st_birthtime:
@@ -85,7 +98,10 @@ def _find_suspicious(file: Path, suspicious_contents: list[str]) -> Iterator[str
         return
     for evil in suspicious_contents:
         if evil.startswith("regex:"):
-            if match := re.search(evil[len("regex:") :], content):
+            pattern = evil[len("regex:") :]
+            flags = re.IGNORECASE | re.DOTALL if "(?s)" in pattern else re.IGNORECASE
+            pattern = pattern.replace("(?s)", "")
+            if match := re.search(pattern, content, flags=flags):
                 yield match.group(0)
         elif evil.lower() in content:
             yield evil
@@ -114,9 +130,15 @@ def webshell(
     """
     logger.info("*** Checking for webshells ***")
     for start_path in paths:
-        for path in (
-            x for x in target.fs.path(start_path).rglob("*.php") if x.is_file() and not _is_known_path(x, known_paths)
-        ):
+        for path in target.fs.path(start_path).rglob("*"):
+            if not path.is_file():
+                continue
+            if path.is_symlink():
+                continue
+            if _is_known_path(path, known_paths):
+                continue
+            if path.suffix.lower() not in WEB_SHELL_EXTENSIONS:
+                continue
             try:
                 stat: stat_result = path.lstat()
                 mode = stat.st_mode & 0o777
@@ -162,30 +184,53 @@ def suspicious_content(
     """
 
     for check in checks:
+        lowercase_exts = {ext.lower() for ext in getattr(check, 'extensions', [])}
+        allowlist_regexes: list[re.Pattern] = []
+        for aw in getattr(check, 'allowlist_patterns', []) or []:
+            if aw.startswith("regex:"):
+                allowlist_regexes.append(re.compile(aw[len("regex:") :], re.IGNORECASE))
+            else:
+                allowlist_regexes.append(re.compile(re.escape(aw), re.IGNORECASE))
         for start_path in check.paths:
             start_path = target.fs.path(start_path)
             if start_path.is_file():
+                if start_path.is_symlink():
+                    continue
                 if not _is_known_path(start_path, check.known_paths) or not start_path.is_file():
+                    if lowercase_exts and start_path.suffix.lower() not in lowercase_exts:
+                        continue
                     for found_content in _find_suspicious(
                         start_path,
                         check.suspicious_contents,
                     ):
+                        is_allowlisted = any(rx.search(found_content) for rx in allowlist_regexes)
+                        alert_message = f"Suspicious content '{found_content}'"
+                        if is_allowlisted:
+                            alert_message += " [allowlisted]"
                         yield FindingRecord(
                             type=f"suspicious-contents-{check.name}",
                             path=start_path,
                             confidence=confidence,
-                            alert=f"Suspicious content '{found_content}'",
+                            alert=alert_message,
                         )
             else:
                 for path in start_path.rglob("*"):
                     if path.is_file():
+                        if path.is_symlink():
+                            continue
                         if not _is_known_path(path, check.known_paths) or not path.is_file():
+                            if lowercase_exts and path.suffix.lower() not in lowercase_exts:
+                                continue
                             for found_content in _find_suspicious(path, check.suspicious_contents):
+                                is_allowlisted = any(rx.search(found_content) for rx in allowlist_regexes)
+                                alert_message = f"Suspicious content '{found_content}'"
+                                if is_allowlisted:
+                                    alert_message += " [allowlisted]"
                                 yield FindingRecord(
                                     type=f"suspicious-contents-{check.name}",
                                     path=path,
                                     confidence=confidence,
-                                    alert=f"Suspicious content '{found_content}'",
+                                    alert=alert_message,
                                 )
 
 
@@ -227,7 +272,7 @@ def yara(
 
     for start_path in paths:
         for path in target.fs.path(start_path).rglob("*"):
-            if path.is_file() and path.stat().st_size <= max_file_size_kb * 1024:
+            if path.is_file() and not path.is_symlink() and path.stat().st_size <= max_file_size_kb * 1024:
                 try:
                     if match := yara_rules_matcher.match(data=path.read_text()):
                         yield FindingRecord(
@@ -253,11 +298,14 @@ def crontab(target: Target, confidence: ConfidenceEnum, suspicious_contents: dic
         Iterator[FindingRecord]: Findings
     """
     logger.info("*** Checking for cronjobs ***")
+    cronjobs = []
     try:
-        cronjobs = target.cronjobs()
+        if hasattr(target, "cronjobs"):
+            cronjobs = target.cronjobs()
     except UnsupportedPluginError:
-        logger.debug("No crontabs found")
-        return
+        logger.debug("No crontabs found via plugin; falling back to filesystem scan")
+    except AttributeError:
+        logger.debug("Target has no cronjobs() API; falling back to filesystem scan")
 
     suspicious_crontab_contents = [(key, re.compile(pattern)) for key, pattern in suspicious_contents.items()]
 
@@ -272,13 +320,56 @@ def crontab(target: Target, confidence: ConfidenceEnum, suspicious_contents: dic
                 path=cronjob_record.path,
             )
         for name, pattern in suspicious_crontab_contents:
-            if match := pattern.match(cronjob_record.command):
+            if match := pattern.search(cronjob_record.command):
                 yield FindingRecord(
                     type="cronjob/command",
-                    alert=f"{name} find in crontab comand ({match.group(0)})",
+                    alert=f"{name} found in crontab command ({match.group(0)})",
                     confidence=confidence,
                     path=cronjob_record.path,
                 )
+
+    # Fallback/augment: scan per-user crontabs typically in /var/spool/cron and /var/cron/tabs
+    def _scan_spool_dir(spool_dir: str) -> None:
+        base = target.fs.path(spool_dir)
+        try:
+            exists = base.exists()
+        except Exception:
+            exists = False
+        if not exists or not base.is_dir():
+            return
+        for entry in base.iterdir():
+            if not entry.is_file():
+                continue
+            username = entry.name
+            try:
+                lines = entry.read_text(encoding="utf-8", errors="ignore").splitlines()
+            except Exception:
+                continue
+            for line in lines:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", stripped):
+                    continue
+                if username == "nobody":
+                    yield FindingRecord(
+                        type="cronjob/user",
+                        alert="Crontab by nobody user observed",
+                        confidence=confidence,
+                        path=entry,
+                    )
+                for name, pattern in suspicious_crontab_contents:
+                    if match := pattern.search(stripped):
+                        yield FindingRecord(
+                            type="cronjob/command",
+                            alert=f"{name} found in crontab command ({match.group(0)})",
+                            confidence=confidence,
+                            path=entry,
+                        )
+
+    if hasattr(target, "fs"):
+        yield from _scan_spool_dir("/var/spool/cron")
+        yield from _scan_spool_dir("/var/cron/tabs")
 
 
 def binaries(
@@ -323,7 +414,7 @@ def binaries(
                 )
 
 
-def _compute_entropy(data: bytes) -> int:
+def _compute_entropy(data: bytes) -> float:
     byte_counts = Counter(data)
     total_bytes = len(data)
     probabilities = [counter / total_bytes for counter in byte_counts.values()]
@@ -414,7 +505,7 @@ def mime_type(
     suspicious_mime_types = set(suspicious_mime_types)
     for start_path in paths:
         for path in target.fs.path(start_path).rglob("*"):
-            if path.is_file():
+            if path.is_file() and not path.is_symlink():
                 mime_type = magic.Magic(mime=True).from_buffer(path.open("rb").read(2048))
                 if mime_type in suspicious_mime_types:
                     yield FindingRecord(
@@ -445,6 +536,8 @@ def core_dump(
 
     threshold_timestamp = (datetime.combine(creation_date_threshold, datetime.min.time())).timestamp()
     for path in target.fs.path("/var/core").rglob("NSPPE*"):
+        if path.is_symlink():
+            continue
         creation_timestamp = path.stat().st_ctime
         if creation_timestamp > threshold_timestamp:
             yield FindingRecord(
@@ -486,7 +579,7 @@ def magic_bytes(
 
     for start_path in paths:
         for path in target.fs.path(start_path).rglob("*"):
-            if path.is_file():
+            if path.is_file() and not path.is_symlink():
                 for filetype, bytes_str in suspicious_bytes.items():
                     expected_magic_bytes = bytes.fromhex(bytes_str)
                     if path.open("rb").read(len(expected_magic_bytes)) == expected_magic_bytes:
@@ -496,3 +589,215 @@ def magic_bytes(
                             confidence=confidence,
                             alert=f"File {path} has suspicious magic bytes, likely {filetype}: '{bytes_str}' is present",
                         )
+
+
+def ns_conf(
+    target: Target,
+    confidence: ConfidenceEnum,
+    path: str,
+    suspicious_patterns: list[str],
+    allowlist_patterns: list[str],
+) -> Iterator[FindingRecord]:
+    """Parse ns.conf for suspicious portal binding, plugins, or responder injections.
+
+    Pattern examples to supply from YAML:
+      - regex:add responder policy .* (http|https)://
+      - regex:bind vpn vserver .* -portaltheme\s+(?!Default)\w+
+      - regex:set vpn parameter .* -clientlessVpnMode ON
+      - regex:add vpn portaltheme .* -source\s+(http|https)://
+      - regex:(?s)add responder action .*?Q\("https?://
+    """
+    logger.info("*** Checking ns.conf for suspicious configuration ***")
+    conf_path = target.fs.path(path)
+
+    def _read_conf_with_includes(p: Path, visited: set[str]) -> str:
+        text_local = ""
+        try:
+            text_local = p.read_text(encoding="utf-8", errors="ignore")
+        except Exception:
+            return ""
+        text_local = re.sub(r"\\\n\s*", " ", text_local)
+        includes: list[str] = []
+        try:
+            for m in re.finditer(r"(?m)^\s*include\s+\"?([^\s\"]+)\"?", text_local):
+                includes.append(m.group(1))
+        except Exception:
+            includes = []
+        base_dir = p.parent
+        for inc in includes:
+            try:
+                inc_path = base_dir.joinpath(inc) if not inc.startswith("/") else target.fs.path(inc)
+                if inc_path.is_symlink():
+                    continue
+                inc_str = str(inc_path)
+                if inc_str in visited:
+                    continue
+                visited.add(inc_str)
+                text_local += "\n" + _read_conf_with_includes(inc_path, visited)
+            except Exception:
+                continue
+        return text_local
+
+    try:
+        text = _read_conf_with_includes(conf_path, visited=set([str(conf_path)]))
+    except Exception:
+        return
+
+    def compile_list(xs: list[str]) -> list[re.Pattern]:
+        compiled: list[re.Pattern] = []
+        for x in xs or []:
+            if x.startswith("regex:"):
+                compiled.append(re.compile(x[len("regex:") :], re.IGNORECASE | re.DOTALL))
+            else:
+                compiled.append(re.compile(re.escape(x), re.IGNORECASE))
+        return compiled
+
+    suspicious_rx = compile_list(suspicious_patterns)
+    allowlist_rx = compile_list(allowlist_patterns)
+
+    for rx in suspicious_rx:
+        for m in rx.finditer(text):
+            start, end = m.span()
+            line_start = text.rfind("\n", 0, start) + 1
+            line_end_pos = text.find("\n", end)
+            if line_end_pos == -1:
+                line_end_pos = len(text)
+            snippet = text[line_start:line_end_pos]
+            is_allowlisted = any(a.search(snippet) for a in allowlist_rx)
+            preview = snippet[:160].replace("\n", " ")
+            alert = f"ns.conf match: {preview}"
+            if is_allowlisted:
+                alert += " [allowlisted]"
+            yield FindingRecord(
+                type="ns-conf/suspicious",
+                path=conf_path,
+                confidence=confidence,
+                alert=alert,
+            )
+
+def recent_changes(
+    target: Target, confidence: ConfidenceEnum, paths: list[str], days: int, extensions: list[str]
+) -> Iterator[FindingRecord]:
+    """List files in portal directories changed within the last N days filtered by extensions."""
+    logger.info("*** Checking for recent changes in portal directories ***")
+
+    now = datetime.now().timestamp()
+    delta_seconds = days * 24 * 60 * 60
+    lowercase_exts = {ext.lower() for ext in extensions}
+
+    seen_paths = set()
+    for start_path in paths:
+        start = target.fs.path(start_path)
+        try:
+            exists = start.exists()
+        except Exception:
+            exists = False
+        if not exists:
+            continue
+        for path in start.rglob("*"):
+            if not path.is_file() or path.is_symlink():
+                continue
+            if lowercase_exts:
+                suffix = path.suffix.lower()
+                if suffix not in lowercase_exts:
+                    continue
+            try:
+                mtime = path.stat().st_mtime
+            except Exception:
+                continue
+            if now - mtime <= delta_seconds:
+                if str(path) in seen_paths:
+                    continue
+                seen_paths.add(str(path))
+                yield FindingRecord(
+                    type="recent-change",
+                    path=path,
+                    confidence=confidence,
+                    alert=f"File modified within last {days} days",
+                )
+
+
+def tiny_backdoor(
+    target: Target,
+    confidence: ConfidenceEnum,
+    paths: list[str],
+    max_size_kb: int,
+    extensions: list[str],
+    suspicious_patterns: list[str],
+) -> Iterator[FindingRecord]:
+    """Detect tiny potential backdoors in portal directories by size and pattern match.
+
+    Scans any small, text-like files (<= max_size_kb) regardless of extension, plus PHP-open overrides.
+    Extensions list remains supported but is no longer required; non-matching extensions are scanned if the file
+    decodes to non-empty text.
+    """
+    logger.info("*** Checking for tiny potential backdoors in portal directories ***")
+
+    compiled_regexes: list[re.Pattern] = []
+    for pattern in suspicious_patterns:
+        if pattern.startswith("regex:"):
+            compiled_regexes.append(re.compile(pattern[len("regex:") :], re.IGNORECASE))
+        else:
+            compiled_regexes.append(re.compile(re.escape(pattern), re.IGNORECASE))
+
+    lowercase_exts = {ext.lower() for ext in extensions}
+    max_bytes = max_size_kb * 1024
+
+    seen_paths = set()
+    for start_path in paths:
+        start = target.fs.path(start_path)
+        try:
+            exists = start.exists()
+        except Exception:
+            exists = False
+        if not exists:
+            continue
+        for path in start.rglob("*"):
+            if not path.is_file() or path.is_symlink():
+                continue
+            try:
+                size = path.stat().st_size
+            except Exception:
+                continue
+            if size > max_bytes:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except Exception:
+                continue
+            # Allow scanning tiny files with PHP open tag even if extension is non-PHP
+            php_open = re.search(r"<\?(php|=)", text, re.IGNORECASE) is not None
+            # Text-like heuristic: any non-whitespace content
+            is_text_like = bool(text.strip())
+            if lowercase_exts:
+                suffix = path.suffix.lower()
+                if suffix not in lowercase_exts and not (is_text_like or php_open):
+                    continue
+            matched = False
+            for rx in compiled_regexes:
+                if rx.search(text):
+                    if str(path) in seen_paths:
+                        matched = True
+                        break
+                    seen_paths.add(str(path))
+                    yield FindingRecord(
+                        type="tiny-backdoor",
+                        path=path,
+                        confidence=confidence,
+                        alert=f"Tiny file ({size} bytes) matched pattern: {rx.pattern[:80]}",
+                    )
+                    matched = True
+                    break
+            # If no specific pattern matched, but file contains a PHP open tag and is not a PHP extension,
+            # emit a low-specificity finding to surface parked PHP in non-PHP files.
+            if not matched and php_open:
+                suffix = path.suffix.lower() or ''
+                if str(path) not in seen_paths:
+                    seen_paths.add(str(path))
+                    context = "non-PHP extension" if (lowercase_exts and suffix not in lowercase_exts) else "PHP extension"
+                    yield FindingRecord(
+                        type="tiny-backdoor-php-open",
+                        path=path,
+                        confidence=confidence,
+                        alert=f"Tiny file ({size} bytes) contains PHP open tag ({context}: {suffix or 'no extension'})",
+                    )

--- a/disk-image-checks/src/checker/models.py
+++ b/disk-image-checks/src/checker/models.py
@@ -45,11 +45,17 @@ class WebshellArgs(BaseModel):
 class SuspiciousContentCheckArgs(BaseModel):
     name: str
     suspicious_contents: list[str]
-    paths: list[str] = "/"
-    known_paths: list[str] = []
+    paths: list[str] = Field(default_factory=list)
+    known_paths: list[str] = Field(default_factory=list)
+    extensions: list[str] = Field(default_factory=list)
+    allowlist_patterns: list[str] = Field(default_factory=list)
 
     @field_validator("suspicious_contents")
     def validate_regex(cls, string):
+        return suspicious_content_validate_regex(string)
+
+    @field_validator("allowlist_patterns")
+    def validate_allowlist_regex(cls, string):
         return suspicious_content_validate_regex(string)
 
 
@@ -156,6 +162,54 @@ class MagicBytesCheck(BaseCheck):
     args: MagicBytesArgs
 
 
+class NsConfArgs(BaseModel):
+    path: str = "/nsconfig/ns.conf"
+    suspicious_patterns: list[str] = []
+    allowlist_patterns: list[str] = []
+
+    @field_validator("suspicious_patterns")
+    def validate_nsconf_regex(cls, string):
+        return suspicious_content_validate_regex(string)
+
+    @field_validator("allowlist_patterns")
+    def validate_nsconf_allowlist_regex(cls, string):
+        return suspicious_content_validate_regex(string)
+
+
+class NsConfCheck(BaseCheck):
+    check: Literal["ns_conf"] = "ns_conf"
+    args: NsConfArgs
+
+
+class RecentChangesArgs(BaseModel):
+    paths: list[str] = []
+    days: int = 90
+    extensions: list[str] = []
+
+
+class TinyBackdoorArgs(BaseModel):
+    paths: list[str] = []
+    max_size_kb: int = 2
+    extensions: list[str] = []
+    suspicious_patterns: list[str] = []
+
+    @field_validator("suspicious_patterns", mode="before")
+    @classmethod
+    def validate_regex_list(cls, v):
+        if not isinstance(v, list):
+            raise TypeError("suspicious_patterns must be list[str]")
+        return [suspicious_content_validate_regex(x) for x in v]
+
+
+class RecentChangesCheck(BaseCheck):
+    check: Literal["recent_changes"] = "recent_changes"
+    args: RecentChangesArgs
+
+
+class TinyBackdoorCheck(BaseCheck):
+    check: Literal["tiny_backdoor"] = "tiny_backdoor"
+    args: TinyBackdoorArgs
+
 ALL_CHECKS = [
     "timestomp",
     "webshell",
@@ -168,6 +222,9 @@ ALL_CHECKS = [
     "mime_type",
     "core_dump",
     "magic_bytes",
+    "ns_conf",
+    "recent_changes",
+    "tiny_backdoor",
 ]
 
 ValidCheckType = Annotated[
@@ -183,6 +240,9 @@ ValidCheckType = Annotated[
         KnownBadFilesCheck,
         CoreDumpCheck,
         MagicBytesCheck,
+        NsConfCheck,
+        RecentChangesCheck,
+        TinyBackdoorCheck,
     ],
     Field(discriminator="check"),
 ]


### PR DESCRIPTION
- Add targeted triage for NetScaler portal/UI:
  - recent_changes: list recent file modifications in portal paths
  - tiny_backdoor: detect tiny PHP/one‑liner backdoors (extension-aware, PHP-open tag heuristic)
  - ns_conf: flag suspicious ns.conf constructs (non-default themes, responder redirects/injections, risky params) with allowlists for common IdPs
- Expand suspicious_content:
  - portal_exfil (JS/HTML exfil APIs, redirects, WebSocket/EventSource, clipboard, postMessage; supports data:/blob: and backticks)
  - per-check extension filters and allowlists; symlink skipping; UTF‑8 decode with ignore; de-duplication
- Broaden webshell coverage to PHP family extensions; symlink-aware scanning
- Improve cron scanning: fallback to per-user crontab spool if plugin API unavailable

**Notes for reviewers**
- Alowlists can be tuned per environment
- New checks are opt-in/configured via `checks.yaml`