### PR TITLE
live-host-bash-check: rc persistence sweep and portal triage additions

### DIFF
--- a/live-host-bash-check/TLPCLEAR_check_script_cve-2025-6543-v1.8.sh
+++ b/live-host-bash-check/TLPCLEAR_check_script_cve-2025-6543-v1.8.sh
@@ -30,13 +30,64 @@ run_checks() {
     echo -e "\n===== NSPPE core dumps (low confidence indicator) =====" >> "$LOGFILE"
     find /var/core/ -iname 'NSPPE*' -exec ls -al {} \; 1>>"$LOGFILE"
     
-    echo -e "\n===== Checking rc.netscaler for backdoor =====" >> "$LOGFILE" 
-    grep python /flash/nsconfig/rc.netscaler >> "$LOGFILE"
+    echo -e "\n===== Checking rc scripts for persistence/backdoors =====" >> "$LOGFILE" 
+    RC_FILES=(
+      "/flash/nsconfig/rc.netscaler"
+      "/etc/rc" "/etc/rc.conf" "/etc/rc.conf.local" "/etc/rc.local"
+    )
+    for f in "${RC_FILES[@]}"; do
+      [ -f "$f" ] || continue
+      echo "-- Inspecting: $f" >> "$LOGFILE"
+      grep -En "python3?\s+-c|(curl|wget)[^\n]*\|\s*sh|touch\s+-t|nohup\s|screen\s|https?://|(^|[^0-9])([0-9]{1,3}\.){3}[0-9]{1,3}([^0-9]|$)" "$f" 2>/dev/null >> "$LOGFILE" || true
+    done
+    if [ -d "/etc/rc.d" ]; then
+      echo "-- Inspecting: /etc/rc.d/*" >> "$LOGFILE"
+      grep -RInE "python3?\s+-c|(curl|wget)[^\n]*\|\s*sh|touch\s+-t|nohup\s|screen\s|https?://|(^|[^0-9])([0-9]{1,3}\.){3}[0-9]{1,3}([^0-9]|$)" /etc/rc.d 2>/dev/null >> "$LOGFILE" || true
+    fi
 
     echo -e "\n===== Checking httpd configuration changes =====" >> "$LOGFILE"
     ext=$(grep 'httpd-php' /etc/httpd.conf | grep -oE '\.[A-Za-z0-9]+' | grep -Ev '\.phps?$') && [ -n "$ext" ] && find /var/netscaler -type f -name "*$ext" >> "$LOGFILE"  
     grep -E -C 1 "#\s+Require all denied" /etc/httpd.conf >> "$LOGFILE" 
     grep -E -C 1 "#\s+php_flag engine off" /etc/httpd.conf >> "$LOGFILE"
+
+    echo -e "\n===== Portal/UI directories triage =====" >> "$LOGFILE"
+    PORTAL_DIRS=(
+      "/var/netscaler/logon"
+      "/var/netscaler/logon/LogonPoint"
+      "/var/netscaler/logon/themes"
+      "/var/vpn"
+      "/netscaler/ns_gui/vpn"
+    )
+
+    for d in "${PORTAL_DIRS[@]}"; do
+      [ -d "$d" ] || continue
+      echo "## Portal check: $d" >> "$LOGFILE"
+
+      echo "-- Files changed in last 90 days (php/html/xhtml/js/json/css) --" >> "$LOGFILE"
+      find "$d" -type f \( -name '*.php' -o -name '*.xhtml' -o -name '*.js' -o -name '*.html' -o -name '*.json' -o -name '*.css' \) -mtime -90 -print0 \
+        | xargs -0 stat -f '%Sm %N' -t '%Y-%m-%d %H:%M' 2>/dev/null >> "$LOGFILE"
+
+      echo "-- External script or data exfil references --" >> "$LOGFILE"
+      grep -RInE '<script[^>]+src=["'"'"']https?://' "$d" 2>/dev/null >> "$LOGFILE" || true
+      grep -RInE 'fetch\(\s*["'"'"']https?://|sendBeacon\(\s*["'"'"']https?://|new[[:space:]]+Image\(\)\.src[[:space:]]*=[[:space:]]*["'"'"']https?://|postMessage\(|location\.(href|assign)[[:space:]]*=|window\.location[[:space:]]*=' "$d" 2>/dev/null >> "$LOGFILE" || true
+
+      echo "-- Tiny potential one-liner shells (<2KB) --" >> "$LOGFILE"
+      find "$d" -type f \( -name '*.php' -o -name '*.xhtml' -o -name '*.js' -o -name '*.css' \) -size -2k -print0 \
+        | xargs -0 grep -Il . 2>/dev/null \
+        | xargs -I{} sh -c "grep -HnE '(^|[^.])exec\(|system\(|shell_exec\(|passthru\(|popen\(|proc_open\(|base64_decode\(|assert\(|eval\(|preg_replace\([^)]*\/e[^)]*\)' '{}' || true" >> "$LOGFILE"
+
+      echo "-- Tiny files with PHP open tag (<2KB, any extension) --" >> "$LOGFILE"
+      find "$d" -type f -size -2k -print0 \
+        | xargs -0 grep -Il -m1 -E '^<\?(php|=)' 2>/dev/null >> "$LOGFILE" || true
+
+      if ls "$d"/*.xml >/dev/null 2>&1; then
+        echo "-- plugins XML external script references --" >> "$LOGFILE"
+        grep -RInE '\bsrc=["'"'"']https?://|<plugin[^>]+src=["'"'"']https?://' "$d"/*.xml 2>/dev/null >> "$LOGFILE" || true
+      fi
+
+      find "$d" -type f -name 'strings.*.json' -print0 \
+        | xargs -0 grep -InE 'https?://' 2>/dev/null >> "$LOGFILE" || true
+    done
 
     echo -e "\nAll checks completed. Log saved to $LOGFILE"
 }


### PR DESCRIPTION
- Scan rc files: /flash/nsconfig/rc.netscaler, /etc/rc, /etc/rc.conf, /etc/rc.conf.local, /etc/rc.local, and /etc/rc.d/*
- Portal paths aligned with disk-image checks (/var/netscaler/logon, LogonPoint, themes, /var/vpn, /netscaler/ns_gui/vpn)
- Greps are resilient (`|| true`) and use extended patterns

